### PR TITLE
add action to submit HySDS job for NISAR ECMWF task

### DIFF
--- a/src/unity_initiator/actions/submit_hysds_job.py
+++ b/src/unity_initiator/actions/submit_hysds_job.py
@@ -1,0 +1,56 @@
+import uuid
+from datetime import datetime
+
+import httpx
+
+from ..utils.logger import logger
+from .base import Action
+
+__all__ = ["SubmitHysdsJob"]
+
+
+class SubmitHysdsJob(Action):
+    def __init__(self, payload, payload_info, params):
+        super().__init__(payload, payload_info, params)
+        logger.info("instantiated %s", __class__.__name__)
+
+    def execute(self):
+        """Submit job to mozart via REST API."""
+
+        # setup url and request body
+        url = f"{self._params['mozart_base_api_endpoint']}/api/v0.1/job/submit"
+        body = {
+            "queue": self._params["queue"],
+            "priority": self._params.get("priority", 0),
+            "tags": json.dumps(self._params.get("tags", [])),
+            "type": self._params["job_spec"],
+            "params": json.dumps(job_params),
+            "name": f"{self._params['job_spec'].split(':')[0]}-{str(uuid.uuid4())}"
+        }
+
+        # build job params
+        job_params = {
+            "payload": self._payload,
+            "payload_info": self._payload_info,
+            "on_success": self._params["on_success"],
+        }
+
+        # submit job
+        logger.info("job URL: %s", url)
+        logger.info("job params: %s", json.dumps(body, indent=2, sort_keys=True))
+        response = httpx.post(url, data=body, verify=False)  # nosec
+        if response.status_code in (200, 201):
+            success = True
+            resp = response.json()
+            logger.info(
+                "Successfully submitted HySDS job %s: %s",
+                self._params["job_spec"],
+                resp,
+            )
+        else:
+            success = False
+            resp = response.text
+            logger.info(
+                "Failed to submit HySDS job %s: %s", self._params["job_spec"], resp
+            )
+        return {"success": success, "response": resp}

--- a/src/unity_initiator/actions/submit_hysds_job.py
+++ b/src/unity_initiator/actions/submit_hysds_job.py
@@ -1,5 +1,5 @@
+import json
 import uuid
-from datetime import datetime
 
 import httpx
 
@@ -17,22 +17,22 @@ class SubmitHysdsJob(Action):
     def execute(self):
         """Submit job to mozart via REST API."""
 
+        # build job params
+        job_params = {
+            "payload": self._payload,
+            "payload_info": self._payload_info,
+            "on_success": self._params["on_success"],
+        }
+
         # setup url and request body
-        url = f"{self._params['mozart_base_api_endpoint']}/api/v0.1/job/submit"
+        url = self._params["mozart_base_api_endpoint"]
         body = {
             "queue": self._params["queue"],
             "priority": self._params.get("priority", 0),
             "tags": json.dumps(self._params.get("tags", [])),
             "type": self._params["job_spec"],
             "params": json.dumps(job_params),
-            "name": f"{self._params['job_spec'].split(':')[0]}-{str(uuid.uuid4())}"
-        }
-
-        # build job params
-        job_params = {
-            "payload": self._payload,
-            "payload_info": self._payload_info,
-            "on_success": self._params["on_success"],
+            "name": f"{self._params['job_spec'].split(':')[0]}-{str(uuid.uuid4())}",
         }
 
         # submit job

--- a/src/unity_initiator/resources/routers_schema.yaml
+++ b/src/unity_initiator/resources/routers_schema.yaml
@@ -36,7 +36,7 @@ evaluator_config:
 # Currently only 2 types of actions are supported:
 # 1. submit payload to an SNS topic
 # 2. submit payload to an airflow DAG
-action_config: any(include("submit_dag_by_id_action"), include("submit_to_sns_topic_action"), include("submit_ogc_process_execution_action"))
+action_config: any(include("submit_dag_by_id_action"), include("submit_to_sns_topic_action"), include("submit_ogc_process_execution_action"), include("submit_hysds_job_action"))
 
 # Configuration for submitting a payload to an airflow DAG.
 submit_dag_by_id_action:
@@ -70,7 +70,7 @@ submit_ogc_process_execution_action:
     on_success: include("on_success_actions", required=False)
 
 # Configuration for submitting a HySDS job
-submit_hysds_job:
+submit_hysds_job_action:
   name: str(equals="submit_hysds_job")
   params:
     mozart_base_api_endpoint: str(required=True)

--- a/src/unity_initiator/resources/routers_schema.yaml
+++ b/src/unity_initiator/resources/routers_schema.yaml
@@ -69,6 +69,17 @@ submit_ogc_process_execution_action:
     execution_subscriber: map(required=False)
     on_success: include("on_success_actions", required=False)
 
+# Configuration for submitting a HySDS job
+submit_hysds_job:
+  name: str(equals="submit_hysds_job")
+  params:
+    mozart_base_api_endpoint: str(required=True)
+    job_spec: str(required=True)
+    queue: str(required=True)
+    priority: int(min=0, max=10, required=False)
+    tags: list(str(), required=False)
+    on_success: include("on_success_actions", required=False)
+
 # Configuration to pass onto the evaluator to use when evaluation is a success.
 on_success_actions:
   actions: list(include("action_config"), required=True, min=1, max=1)

--- a/tests/resources/test_router.yaml
+++ b/tests/resources/test_router.yaml
@@ -150,7 +150,7 @@ initiator_config:
                     actions:
                       - name: submit_hysds_job
                         params:
-                          mozart_base_api_endpoint: xxx
+                          mozart_base_api_endpoint: https://example.com/api/v0.1/job/submit
                           job_spec: submit_airs_ingest:v1
                           queue: ingest_queue
                           priority: 0

--- a/tests/resources/test_router.yaml
+++ b/tests/resources/test_router.yaml
@@ -148,13 +148,15 @@ initiator_config:
                   topic_arn: arn:aws:sns:hilo-hawaii-1:123456789012:eval_airs_ingest
                   on_success:
                     actions:
-                      - name: submit_dag_by_id
+                      - name: submit_hysds_job
                         params:
-                          dag_id: submit_airs_ingest
-                          airflow_base_api_endpoint: xxx
-                          airflow_username: <SSM parameter, e.g. /unity/airflow/username> <ARN to username entry in AWS Secrets Manager>
-                          airflow_password: <SSM parameter, e.g. /unity/airflow/password> <ARN to password entry in Secrets Manager>
-
+                          mozart_base_api_endpoint: xxx
+                          job_spec: submit_airs_ingest:v1
+                          queue: ingest_queue
+                          priority: 0
+                          tags:
+                            - airs
+                            - hysds
 
       - regexes:
           - '(?<=/)(?P<filename>hello_world\.txt)$'


### PR DESCRIPTION
## Purpose
The purpose of this PR is to implement a new action that can submit jobs to a HySDS cluster. This feature will enable NISAR to utilize the initiator framework to ingest and process a stream of ECMWF files for NISAR L1, L2, L3 processing.

## Proposed Changes
- added new action, `submit_hysds_job`
- updated router schema
- modified AIRS RetStd example to submit job to HySDS
- added regression and unit tests

## Issues
N/A

## Testing
- see regression/unit testing results at https://github.com/unity-sds/unity-initiator/actions