### PR TITLE
Changed mcp instances to smce

### DIFF
--- a/terraform-unity/evaluators/sns-sqs-lambda/README.md
+++ b/terraform-unity/evaluators/sns-sqs-lambda/README.md
@@ -45,7 +45,7 @@ No modules.
 | [aws_ssm_parameter.evaluator_lambda_function_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [null_resource.build_lambda_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy.mcp_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.smce_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [local_file.version](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
 ## Inputs

--- a/terraform-unity/evaluators/sns-sqs-lambda/data.tf
+++ b/terraform-unity/evaluators/sns-sqs-lambda/data.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
+data "aws_iam_policy" "smce_operator_policy" {
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 data "local_file" "version" {

--- a/terraform-unity/evaluators/sns-sqs-lambda/main.tf
+++ b/terraform-unity/evaluators/sns-sqs-lambda/main.tf
@@ -59,7 +59,7 @@ resource "aws_iam_role" "evaluator_lambda_iam_role" {
       },
     ],
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags                 = local.tags
 }
 

--- a/terraform-unity/initiator/README.md
+++ b/terraform-unity/initiator/README.md
@@ -43,7 +43,7 @@ No modules.
 | [aws_sqs_queue_policy.initiator_queue_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
 | [aws_ssm_parameter.initiator_lambda_function_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [null_resource.build_lambda_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [aws_iam_policy.mcp_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.smce_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [local_file.version](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
 ## Inputs

--- a/terraform-unity/initiator/data.tf
+++ b/terraform-unity/initiator/data.tf
@@ -1,5 +1,5 @@
-data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
+data "aws_iam_policy" "smce_operator_policy" {
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 data "local_file" "version" {

--- a/terraform-unity/initiator/main.tf
+++ b/terraform-unity/initiator/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role" "initiator_lambda_iam_role" {
       },
     ],
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags                 = local.tags
 }
 

--- a/terraform-unity/triggers/cmr-query/README.md
+++ b/terraform-unity/triggers/cmr-query/README.md
@@ -43,7 +43,7 @@ No modules.
 | [aws_scheduler_schedule.run_cmr_query](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule) | resource |
 | [null_resource.build_lambda_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy.mcp_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.smce_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [local_file.version](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 

--- a/terraform-unity/triggers/cmr-query/data.tf
+++ b/terraform-unity/triggers/cmr-query/data.tf
@@ -2,8 +2,8 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
+data "aws_iam_policy" "smce_operator_policy" {
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 data "local_file" "version" {

--- a/terraform-unity/triggers/cmr-query/main.tf
+++ b/terraform-unity/triggers/cmr-query/main.tf
@@ -88,7 +88,7 @@ resource "aws_iam_role" "cmr_query_lambda_iam_role" {
       },
     ],
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags                 = local.tags
 }
 
@@ -161,7 +161,7 @@ resource "aws_iam_role" "scheduler" {
       }
     ]
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags                 = local.tags
 }
 

--- a/terraform-unity/triggers/scheduled-task-instrumented/README.md
+++ b/terraform-unity/triggers/scheduled-task-instrumented/README.md
@@ -39,7 +39,7 @@ No modules.
 | [aws_s3_object.lambda_package](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_scheduler_schedule.run_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule) | resource |
 | [null_resource.build_lambda_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [aws_iam_policy.mcp_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.smce_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [local_file.version](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
 ## Inputs

--- a/terraform-unity/triggers/scheduled-task-instrumented/data.tf
+++ b/terraform-unity/triggers/scheduled-task-instrumented/data.tf
@@ -1,5 +1,5 @@
-data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
+data "aws_iam_policy" "smce_operator_policy" {
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 data "local_file" "version" {

--- a/terraform-unity/triggers/scheduled-task-instrumented/main.tf
+++ b/terraform-unity/triggers/scheduled-task-instrumented/main.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role" "scheduled_task_lambda_iam_role" {
       },
     ],
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags                 = local.tags
 }
 
@@ -99,7 +99,7 @@ resource "aws_iam_role" "scheduler" {
       }
     ]
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags                 = local.tags
 }
 

--- a/terraform-unity/triggers/scheduled-task/README.md
+++ b/terraform-unity/triggers/scheduled-task/README.md
@@ -36,7 +36,7 @@ No modules.
 | [aws_lambda_function_event_invoke_config.invoke_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_scheduler_schedule.run_scheduled_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule) | resource |
 | [archive_file.lambda_zip_inline](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_iam_policy.mcp_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy.smce_operator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 
 ## Inputs
 

--- a/terraform-unity/triggers/scheduled-task/data.tf
+++ b/terraform-unity/triggers/scheduled-task/data.tf
@@ -1,5 +1,5 @@
-data "aws_iam_policy" "mcp_operator_policy" {
-  name = "mcp-tenantOperator-AMI-APIG"
+data "aws_iam_policy" "smce_operator_policy" {
+  name = "zsmce-tenantOperator-AMI-APIG"
 }
 
 data "archive_file" "lambda_zip_inline" {

--- a/terraform-unity/triggers/scheduled-task/main.tf
+++ b/terraform-unity/triggers/scheduled-task/main.tf
@@ -13,7 +13,7 @@ resource "aws_iam_role" "scheduled_task_lambda_iam_role" {
       },
     ],
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags                 = local.tags
 }
 
@@ -70,7 +70,7 @@ resource "aws_iam_role" "scheduler" {
       }
     ]
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags                 = local.tags
 }
 

--- a/terraform-unity/triggers/scheduled-task/main.tf.cloudwatch_event
+++ b/terraform-unity/triggers/scheduled-task/main.tf.cloudwatch_event
@@ -13,7 +13,7 @@ resource "aws_iam_role" "scheduled_task_lambda_iam_role" {
       },
     ],
   })
-  permissions_boundary = data.aws_iam_policy.mcp_operator_policy.arn
+  permissions_boundary = data.aws_iam_policy.smce_operator_policy.arn
   tags = local.tags
 }
 


### PR DESCRIPTION
## Purpose
Unity has completely transitioned off MCP for SMCE. I have successfully gotten our airflow deployment to work on SMCE with the code changes from my fork of this repo, unity cs infra and unity sps 

## Proposed Changes
- [CHANGE] mcp mentions to smce 
## Issues
Relevant issue: https://github.com/unity-sds/unity-sps/issues/453 
## Testing
Tested airflow instance and checked status on SMCE AWS resources 